### PR TITLE
15685. 드래곤 커브 on Baekjoon

### DIFF
--- a/baekjoon/15685-드래곤 커브.py
+++ b/baekjoon/15685-드래곤 커브.py
@@ -1,0 +1,27 @@
+import sys
+import copy
+
+delta = ((0, 1), (-1, 0), (0, -1), (1, 0))
+y_max = x_max = 101
+board = [[False] * x_max for _ in range(y_max)]
+n = int(sys.stdin.readline())
+for _ in range(n):
+    x, y, d, g = map(int, sys.stdin.readline().split())
+    board[y][x] = True
+    directions = [d]
+    for _ in range(g):
+        directions.extend(reversed(list(map(lambda x : (x+1)%4, copy.deepcopy(directions)))))
+
+    for direction_idx in directions:
+        dy, dx = delta[direction_idx]
+        ny, nx = y + dy, x + dx
+        board[ny][nx] = True
+        y, x = ny, nx
+
+cnt = 0
+for y in range(100):
+    for x in range(100):
+        if board[y][x] and board[y+1][x] and board[y][x+1] and board[y+1][x+1]:
+            cnt += 1
+
+print(cnt)


### PR DESCRIPTION
## Problem
https://www.acmicpc.net/problem/15685

## Solution
구현, 시뮬레이션

## Approach
1. 구현: 각 세대별 방향을 구하는 규칙을 찾는 것이 핵심이었습니다. 다음 세대의 총 방향 리스트는 현재 세대까지 구한 방향 리스트의 각 원소에 1씩 더하고, 4의 나머지를 구한다음 역순으로 추가해주면 구할 수 있습니다. 그렇게 모든 드래곤 커브를 격자에 표시하고, 순회를 하면서 인접한 4방향의 사각형이 모두 True일 경우 cnt값을 1씩 증가시켜주었습니다.

## Complexity
- Time complexity: $O(n*2^g)$
- Space complexity: $O(max(2^g, 101^2))$