### PR TITLE
1774. Closest Dessert Cost on LeetCode

### DIFF
--- a/leetcode/Medium/1774-closest-dessert-cost.py
+++ b/leetcode/Medium/1774-closest-dessert-cost.py
@@ -1,0 +1,22 @@
+class Solution:
+    def closestCost(self, baseCosts: List[int], toppingCosts: List[int], target: int) -> int:
+        ans = float('inf')
+        def back_tracking(topping_idx, total_cost):
+            nonlocal ans
+
+            if abs(target - total_cost) < abs(target - ans):
+                ans = total_cost
+            elif abs(target - total_cost) == abs(target - ans) and total_cost < ans:
+                ans = total_cost
+
+            if total_cost > ans or topping_idx == len(toppingCosts):
+                return
+
+            back_tracking(topping_idx+1, total_cost)
+            back_tracking(topping_idx+1, total_cost + toppingCosts[topping_idx])
+            back_tracking(topping_idx+1, total_cost + 2*toppingCosts[topping_idx])
+        
+        for base_cost in baseCosts:
+            back_tracking(0, base_cost)
+
+        return ans


### PR DESCRIPTION
## Problem
https://leetcode.com/problems/closest-dessert-cost/

## Solution
백트래킹

## Approach
1. 백트래킹: 
n과 m값이 10이하로 매우 작기 때문에 베이스가 되는 아이스크림과 그 위에 올라갈 토핑의 모든 조합을 만들어서 각 조합의 비용을 계산합니다. 그리고 그 비용들 중 가장 target값에 가까운 값을 구하면 됩니다. 토핑의 모든 조합을 구하는 과정은 DFS를 활용했으며, 각 아이스크림 베이스 가격으로부터 시작하여 DFS로 아이스크림과 토핑의 조합으로 발생할 수 있는 모든 비용을 찾았습니다. 그러면서 매번 target에 가까운 비용일 경우 이를 ans값으로 갱신하였습니다. 
여기서 만약 탐색 중간에 비용이 현재 ans값보다 크다면 더 이상 토핑을 추가할 필요가 없으므로 더 이상 탐색을 진행하지 않도록 백트래킹하여 탐색범위를 최적화하였습니다.

## Complexity
- Time complexity: $O(n * 3^m)$
n은 baseCosts 배열의 크기이고 m은 toppingCosts 배열의 크기입니다. 모든 baseCounts 원소에 대해서 백트래킹을 진행하고, 백트래킹은 각 노드마다 3개의 브랜치를 만들어서 탐색합니다.(토핑 0,1,2개) 
- Space complexity: $O(m)$
탐색을 할때 재귀를 사용하므로 콜 스택의 재귀 호출의 최대 횟수를 공간복잡도로 볼 수 있습니다. 이는 toppingCosts의 크기인 m과 같습니다.