### PR TITLE
1539. Kth Missing Positive Number on LeetCode

### DIFF
--- a/leetcode/Easy/1339-kth-missing-positive-number.py
+++ b/leetcode/Easy/1339-kth-missing-positive-number.py
@@ -1,13 +1,11 @@
 class Solution:
     def findKthPositive(self, arr: List[int], k: int) -> int:
-        i, j = 0, 0
-        for num in range(1, 2001):
-            if i < len(arr) and num == arr[i]:
-                i += 1
-                continue
+        l, r = 0, len(arr)
+        while l < r:
+            mid = (l+r)//2
+            if arr[mid] - mid - 1 < k:
+                l = mid+1
             else:
-                j += 1
-            
-            if j == k:
-                return num
+                r = mid
         
+        return l + k

--- a/leetcode/Easy/1339-kth-missing-positive-number.py
+++ b/leetcode/Easy/1339-kth-missing-positive-number.py
@@ -1,0 +1,13 @@
+class Solution:
+    def findKthPositive(self, arr: List[int], k: int) -> int:
+        i, j = 0, 0
+        for num in range(1, 2001):
+            if i < len(arr) and num == arr[i]:
+                i += 1
+                continue
+            else:
+                j += 1
+            
+            if j == k:
+                return num
+        


### PR DESCRIPTION
## Problem
https://leetcode.com/problems/kth-missing-positive-number/description/

## Solution
이진 탐색

## Approach
1. 브루트포스: 
현재 arr에서 가리키는 원소의 인덱스 i와 현재까지 놓친 양의 정수 갯수 j를 사용하여 문제를 해결하였습니다. 원소의 최대값이 1000이고, k의 최대값도 1000이므로 1부터 2000까지 정수를 순회하였습니다. 따라서 시간복잡도는 $O(N)$ 입니다.

2. 이진 탐색:
$O(N)$ 보다 적은 시간복잡도로 문제를 해결하라는 follow up question에 따라 새롭게 문제를 접근해보았습니다. 현재 주어진 배열 arr이 오름차순 정렬이 되어있기때문에 이진탐색을 활용해보았고, `arr[i] - i - 1` 은 현재 i번째 인덱스까지 놓친 원소의 개수를 의미합니다. 


## Complexity
- Time complexity: $O(nlogn)$
- Space complexity: $O(1)$
